### PR TITLE
add http header (Cookies etc...) support

### DIFF
--- a/src/emq_auth_http_cli.erl
+++ b/src/emq_auth_http_cli.erl
@@ -43,10 +43,20 @@ reply({error, Error}) ->
 %% Feed Variables
 %%--------------------------------------------------------------------
 
-feedvar(Params, #mqtt_client{username = Username, client_id = ClientId, peername = {IpAddr, _}}) ->
+feedWsHeader(WsInitialHeaders)  when is_list(WsInitialHeaders) ->
+    F = fun ({K, V}) ->
+                lists:flatten(io_lib:format("~s: ~s", [K, V]))
+        end,
+    string:join(lists:map(F, WsInitialHeaders), "\r\n");
+
+feedWsHeader(WsInitialHeaders) when not is_list(WsInitialHeaders) ->
+    undefined.
+
+feedvar(Params, #mqtt_client{username = Username, client_id = ClientId, ws_initial_headers = WsInitialHeaders, peername = {IpAddr, _}}) ->
     lists:map(fun({Param, "%u"}) -> {Param, Username};
                  ({Param, "%c"}) -> {Param, ClientId};
                  ({Param, "%a"}) -> {Param, inet:ntoa(IpAddr)};
+                 ({Param, "%h"}) -> {Param, feedWsHeader(WsInitialHeaders)};
                  (Param)         -> Param
               end, Params).
 


### PR DESCRIPTION
add http header (Cookies etc...) support 
by pass %h format 

eg
auth.http.auth_req.params = username=%u,password=%P,clientid=%c,ipaddr=%a,ws_initial_headers=%h