### PR TITLE
chore(appup): update appup.src

### DIFF
--- a/src/emqx_auth_http.appup.src
+++ b/src/emqx_auth_http.appup.src
@@ -1,27 +1,14 @@
 %% -*-: erlang -*-
 {VSN,
   [
-    {<<"4.2.[2-3]">>, [
-      {load_module, emqx_auth_http_cli, brutal_purge, soft_purge, []}
-    ]},
-    {"4.2.1", [
+    {<<".*">>, [
       {restart_application, emqx_auth_http}
-    ]},
-    {"4.2.0", [
-      {restart_application, emqx_auth_http}
-    ]},
-    {<<".*">>, []}
+    ]}
   ],
   [
-    {<<"4.2.[2-3]">>, [
-      {load_module, emqx_auth_http_cli, brutal_purge, soft_purge, []}
-    ]},
-    {"4.2.1", [
+    {<<".*">>, [
       {restart_application, emqx_auth_http}
-    ]},
-    {"4.2.0", [
-      {restart_application, emqx_auth_http}
-    ]},
-    {<<".*">>, []}
+    ]}
+
   ]
 }.


### PR DESCRIPTION
For auth type plugins, we restart it directly, which does not hit the existing system. It will only deny new clients the ability to connect in.